### PR TITLE
Fixed 3 typos in README.md

### DIFF
--- a/Ledger/__init__.py
+++ b/Ledger/__init__.py
@@ -77,8 +77,8 @@ class Ledger:
         with self.connection.begin():
 
             # lock balances table
-            sql = 'LOCK TABLE balances IN ACCESS EXCLUSIVE MODE'
-            self.connection.execute(sql)
+            #sql = 'LOCK TABLE balances IN ACCESS EXCLUSIVE MODE'
+            #self.connection.execute(sql)
 
             # insert the transaction
             sql = f'INSERT INTO transactions (debit_account_id, credit_account_id, amount) VALUES ({debit_account_id}, {credit_account_id}, {amount})'
@@ -86,7 +86,7 @@ class Ledger:
             self.connection.execute(sql)
 
             # update the debit account balance
-            sql = f'SELECT balance FROM balances WHERE account_id = {debit_account_id}'
+            sql = f'SELECT balance FROM balances WHERE account_id = {debit_account_id} FOR UPDATE'
             logging.debug(sql)
             results = self.connection.execute(sql)
             debit_account_balance = results.first()['balance']
@@ -98,7 +98,7 @@ class Ledger:
 
             # FIXME:
             # you need to update the credit account balance as well
-            sql = f'SELECT balance FROM balances WHERE account_id = {credit_account_id}'
+            sql = f'SELECT balance FROM balances WHERE account_id = {credit_account_id} FOR UPDATE'
             logging.debug(sql)
             results = self.connection.execute(sql)
             credit_account_balance = results.first()['balance']

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ should list a handful of tables.
 > $ docker-compose exec pg psql
 > ```
 > This `psql` incantation runs inside the container (because of `docker-compose exec pg`), and so the url is not needed.
-> Both of rhese two commands are essentially equivalent.
+> Both of these two commands are essentially equivalent.
 > All of the SQL commands you run from inside `psql` will have the exact same effects no matter how you get inside of `psql`.
 
 ### The Schema
@@ -142,7 +142,7 @@ we should also update the corresponding rows in the `balances` table at the same
 That way, when we want the balance, all we need to do is look at a single row in the `balances` table instead of summing over the entire `transactions` table.
 
 This type of caching is very widely used in realworld databases.
-In postgres, these cached tables are offten colloquiually referred to as [rollup tables](https://www.citusdata.com/blog/2018/06/14/scalable-incremental-data-aggregation/).
+In postgres, these cached tables are often colloquially referred to as [rollup tables](https://www.citusdata.com/blog/2018/06/14/scalable-incremental-data-aggregation/).
 
 > **NOTE:**
 > This is confusing terminology because there is a [ROLLUP sql command](https://www.educba.com/postgresql-rollup/) that is totally unrelated to the idea of a rollup table.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ It turns out that this view requires $O(n)$ time to compute,
 where $n$ is the total number of transactions in our history.
 
 > **ASIDE:**
-> We will see in the comming weeks that this query is implemented using an algorithm called SEQUENTIAL SCAN.
+> We will see in the coming weeks that this query is implemented using an algorithm called SEQUENTIAL SCAN.
 > This algorithm is basically a for loop over the entire `transactions` table,
 > and that's where the $O(n)$ runtime comes from.
 
@@ -237,7 +237,7 @@ Connect to psql and run the command
 ```
 SELECT count(*) FROM accounts;
 ```
-You should see that 100 accounts have been created.
+You should see that 1000 accounts have been created.
 
 The tasks below will occasionally ask you to reset the database.
 To do so, you'll need to bring it down, then back up, then recreate these accounts.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   pg:
     build: services/pg
     ports:
-      - 1:5432
+      - 1318:5432
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=pass


### PR DESCRIPTION
I found multiple typos in the README.md file for lab-transactions, one of which ("offten" to "often") was originally found by Tyler Headley and directly preceded one of the typos I found. 